### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/user/explanations/coordinates.rst
+++ b/docs/user/explanations/coordinates.rst
@@ -66,7 +66,7 @@ as follows:
     - Moving South increases your Z coordinate, so North decreases Z
 
 The minecraft Wiki has a useful diagram of the coordinate system, see
-https://minecraft.fandom.com/wiki/Coordinates.
+https://minecraft.wiki/w/Coordinates.
 
 If you consider the coordinate X=0, Y=0, Z=0 to be the centre of the world
 then our player's position is 653 blocks to the East of the centre, 72 blocks

--- a/docs/user/explanations/mcipc.rst
+++ b/docs/user/explanations/mcipc.rst
@@ -16,7 +16,7 @@ the underlying Python project that we use to communicate with the Minecraft.
 Minecraft provides a remote control mechanism called RCON that gives you
 exactly the same set of admin commands that you may be familiar with if you 
 have player a lot of Minecraft. Those commands are documented here
-https://minecraft.fandom.com/wiki/Commands and let you do pretty much
+https://minecraft.wiki/w/Commands and let you do pretty much
 anything in the world.
 
 Note that due to tab completion in Interactive Python it is quite easy to

--- a/docs/user/tutorials/02-orientation.rst
+++ b/docs/user/tutorials/02-orientation.rst
@@ -63,7 +63,7 @@ quite nice scenery.
 
 If you have not played Minecraft before then take some time to familiarize 
 yourself with the controls and game play. You may find 
-`this wiki <https://minecraft.fandom.com/wiki/Tutorials/Beginner%27s_guide>`_
+`this wiki <https://minecraft.wiki/w/Tutorials/Beginner%27s_guide>`_
 useful if you are a beginner. When you are really to move on type the 
 command ``/kill`` to return to the spawn point.
 

--- a/docs/user/tutorials/03-variables.rst
+++ b/docs/user/tutorials/03-variables.rst
@@ -210,7 +210,7 @@ Yay! You can paste again to create another one.
 
     Say hello to the Iron Golem, your first Python creation!
     
-(See "Creation" in this article https://minecraft.fandom.com/wiki/Iron_Golem
+(See "Creation" in this article https://minecraft.wiki/w/Iron_Golem
 if you don't know about making iron golems)
 
 How does this work? We use ``set_block`` to place all the necessary blocks

--- a/docs/user/tutorials/04-loops.rst
+++ b/docs/user/tutorials/04-loops.rst
@@ -6,7 +6,7 @@ Introduction
 
 For this tutorial we are going to write code that will create a Nether
 Portal. If you don't know about Nether Portals, you can read about them
-here: https://minecraft.fandom.com/wiki/Nether_portal.
+here: https://minecraft.wiki/w/Nether_portal.
 
 A Nether Portal requires a minimum of 14 blocks. Now we could use a similar
 approach as that for the iron golem in the previous tutorial. But that would

--- a/src/mciwb/nbt.py
+++ b/src/mciwb/nbt.py
@@ -24,7 +24,7 @@ def parse_nbt(s_nbt_text: str) -> object:
     - distinction between float, double types (suffixes of f,d)
     - distinction between SNBT and raw JSON (enclosed in single quotes)
 
-    See https://minecraft.fandom.com/wiki/NBT_format
+    See https://minecraft.wiki/w/NBT_format
     """
     try:
         text = preamble_re.sub(r"\1", s_nbt_text)


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki