### PR TITLE
Fixes for signs in 1.20, dependency/lintings updates

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -10,6 +10,9 @@ inputs:
   python_version:
     description: Python version to install
     default: "3.x"
+  lockfiles_artifact_name:
+    description: Lockfiles artifact name
+    default: "lockfiles"
 
 runs:
   using: composite
@@ -36,9 +39,9 @@ runs:
       shell: bash
 
     - name: Upload lockfiles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: lockfiles
+        name: ${{ lockfiles_artifact_name }}
         path: lockfiles
 
     # This eliminates the class of problems where the requirements being given no

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Upload lockfiles
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ lockfiles_artifact_name }}
+        name: ${{ inputs.lockfiles_artifact_name }}
         path: lockfiles
 
     # This eliminates the class of problems where the requirements being given no

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -23,6 +23,7 @@ jobs:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
           python_version: ${{env.CONTAINER_PYTHON}}
+          lockfiles_artifact_name: lockfiles-lint
 
       - name: Lint
         run: tox -e pre-commit,mypy
@@ -59,6 +60,7 @@ jobs:
           python_version: ${{ matrix.python }}
           requirements_file: requirements-test-${{ matrix.os }}-${{ matrix.python }}.txt
           install_options: ${{ matrix.install }}
+          lockfiles_artifact_name: lockfiles-${{ matrix.os }}-${{ matrix.python }}
 
       - name: List dependency tree
         run: pipdeptree
@@ -103,6 +105,7 @@ jobs:
           python_version: ${{env.CONTAINER_PYTHON}}
           requirements_file: requirements.txt
           install_options: dist/*.whl
+          lockfiles_artifact_name: lockfiles
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: ${{env.CONTAINER_PYTHON}}
 
       - name: Lint
         run: tox -e pre-commit,mypy

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -88,7 +88,7 @@ jobs:
           pipx run build
 
       - name: Upload sdist and wheel as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -124,7 +124,7 @@ jobs:
         run: echo IMAGE_REPOSITORY=ghcr.io/$(tr '[:upper:]' '[:lower:]' <<< "${{ github.repository }}") >> $GITHUB_ENV
 
       - name: Download wheel and lockfiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 
@@ -177,7 +177,7 @@ jobs:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-
+          python-version: ${{env.CONTAINER_PYTHON}}
+          
       - name: Build docs
         run: tox -e docs
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,9 @@ name: Docs CI
 on:
   push:
   pull_request:
+env:
+  # The target python version, which must match the Dockerfile version
+  CONTAINER_PYTHON: "3.11"
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python-version: ${{env.CONTAINER_PYTHON}}
+          python_version: ${{env.CONTAINER_PYTHON}}
           
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,8 @@ jobs:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
           python_version: ${{env.CONTAINER_PYTHON}}
-          
+          lockfiles_artifact_name: lockfiles-docs
+
       - name: Build docs
         run: tox -e docs
 

--- a/.github/workflows/docs_clean.yml
+++ b/.github/workflows/docs_clean.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           ref: gh-pages
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{env.CONTAINER_PYTHON}}
+
       - name: removing documentation for branch ${{ github.event.ref }}
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: echo "REF_NAME=${{ github.event.ref }}" >> $GITHUB_ENV

--- a/.github/workflows/docs_clean.yml
+++ b/.github/workflows/docs_clean.yml
@@ -10,6 +10,9 @@ on:
         description: "documentation version to DELETE"
         required: true
         type: string
+env:
+  # The target python version, which must match the Dockerfile version
+  CONTAINER_PYTHON: "3.11"
 
 jobs:
   remove:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python-version: ${{env.CONTAINER_PYTHON}}
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Run weekly to check URL links still resolve
     - cron: "0 8 * * WED"
+env:
+  # The target python version, which must match the Dockerfile version
+  CONTAINER_PYTHON: "3.11"
 
 jobs:
   docs:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python-version: ${{env.CONTAINER_PYTHON}}
+          python_version: ${{env.CONTAINER_PYTHON}}
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -23,6 +23,7 @@ jobs:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
           python_version: ${{env.CONTAINER_PYTHON}}
+          lockfiles_artifact_name: lockfiles-lintcheck
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     "python.languageServer": "Pylance",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "cSpell.words": [
         "addfinalizer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "numpy==1.23.5",
     "typer==0.7.0",
     "mcwb>=0.2.3",
-    "ipython==8.14.0",
+    "ipython==8.20.0",
     "docker>=6",
 ]
 dynamic = ["version"]

--- a/src/demo/gate.py
+++ b/src/demo/gate.py
@@ -1,6 +1,7 @@
 """
 Define a castle gateway with portcullis
 """
+
 from time import sleep
 
 from mciwb.imports import Direction, FillMode, Item, Switch, Vec3, get_client, get_world

--- a/src/demo/gateway.py
+++ b/src/demo/gateway.py
@@ -1,6 +1,7 @@
 """
 Define a castle gateway with portcullis and drawbridge
 """
+
 from time import sleep
 
 from mciwb.imports import Direction, FillMode, Item, Monitor, Switch, Vec3, get_client

--- a/src/mciwb/__main__.py
+++ b/src/mciwb/__main__.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import traitlets
 import typer
 from IPython.terminal.embed import InteractiveShellEmbed
 
@@ -83,10 +84,17 @@ def shell(
 
     log.info("######### Starting Interactive Session ##########\n")
 
+    # This is due to warn_venv not working properly with tox
+    # pytest inside the venv works properly but tox fails due to the warning
+    if test:
+        c = traitlets.config.get_config()
+        c.InteractiveShellEmbed.warn_venv = False
+        shell = InteractiveShellEmbed.instance(config=c)
+    else:
+        shell = InteractiveShellEmbed.instance()
     # Prepare IPython shell with auto-reload so user code edits work immediately
-    shell = InteractiveShellEmbed()
-    shell.magic(r"%load_ext autoreload")
-    shell.magic(r"%autoreload 2")
+    shell.run_line_magic("load_ext", "autoreload")
+    shell.run_line_magic("autoreload", "2")
     # Also suppress traceback to avoid intimidating novice programmers
     ipython = shell.get_ipython()
     ipython._showtraceback = exception_handler  # type: ignore

--- a/src/mciwb/player.py
+++ b/src/mciwb/player.py
@@ -2,6 +2,7 @@
 Represent a player in the world and provide functions for monitoring their
 state
 """
+
 import math
 import re
 from time import sleep

--- a/src/mciwb/server.py
+++ b/src/mciwb/server.py
@@ -1,6 +1,7 @@
 """
 Functions for launching and controlling a Minecraft server in a Docker container.
 """
+
 import shutil
 from datetime import datetime
 from pathlib import Path

--- a/src/mciwb/signs.py
+++ b/src/mciwb/signs.py
@@ -1,6 +1,7 @@
 """
 Add an interactive capability through the placing of command signs in the world
 """
+
 import re
 from time import sleep
 from typing import Callable, Dict
@@ -32,10 +33,11 @@ class Signs:
     providing those functions.
     """
 
-    _re_sign_text = re.compile(r"""Text1: '{"text":"([^"]*)"}'""")
+    _re_sign_text = re.compile("""front_text.*messages: \\['"([^"]*)"',""")
     _re_sign_entity = (
         """minecraft:oak_sign{{"""
-        """BlockEntityTag:{{Text1:'{{"text":"{0}"}}'}},"""
+        """BlockEntityTag:{{front_text:{{"""
+        """messages:['["{0}"]','[""]','[""]','[""]']}}}},"""
         """display:{{Name:'{{"text":"{0}"}}'}}"""
         """}}"""
     )

--- a/tests/mockclient.py
+++ b/tests/mockclient.py
@@ -2,6 +2,7 @@
 A mock client for testing functions that call the minecraft server.
 This mocks a world of 100 blocks square with origin in the middle.
 """
+
 from math import floor
 
 import numpy as np
@@ -69,13 +70,13 @@ class MockClient:
         v_stop = v_start + vol.size
         d_stop = dest + vol.size
 
-        self.world[
-            dest.x : d_stop.x, dest.y : d_stop.y, dest.z : d_stop.z
-        ] = self.world[
-            v_start.x : v_stop.x,
-            v_start.y : v_stop.y,
-            v_start.z : v_stop.z,
-        ]
+        self.world[dest.x : d_stop.x, dest.y : d_stop.y, dest.z : d_stop.z] = (
+            self.world[
+                v_start.x : v_stop.x,
+                v_start.y : v_stop.y,
+                v_start.z : v_stop.z,
+            ]
+        )
         return f"cloned {v_start} : {v_stop} to {dest}"
 
     @property

--- a/tests/test_system/test_cli.py
+++ b/tests/test_system/test_cli.py
@@ -45,10 +45,10 @@ def test_repr(tmp_path: Path, minecraft_container, minecraft_client, minecraft_p
 def test_backup(tmp_path):
     checks = ["ERROR", "WARNING"]
 
-    server_folder = Path(tempfile.gettempdir()) / "test-backup-server"
-    server_folder2 = Path(tempfile.gettempdir()) / "test-backup-server2"
-    backup_folder = Path(tempfile.gettempdir()) / "test-backup-backup"
-    backup_folder_tmp = Path(tempfile.gettempdir()) / "test-backup-backup"
+    server_folder = Path.home() / "test-backup-server"
+    server_folder2 = Path.home() / "test-backup-server2"
+    backup_folder = Path.home() / "test-backup-backup"
+    backup_folder_tmp = Path.home() / "test-backup-backup"
 
     result = run_cli(
         "start",

--- a/tests/test_system/test_cli.py
+++ b/tests/test_system/test_cli.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 from shutil import copytree
 
+import pytest
 from typer.testing import CliRunner
 
 from mciwb.__main__ import cli

--- a/tests/test_system/test_cli.py
+++ b/tests/test_system/test_cli.py
@@ -45,10 +45,10 @@ def test_repr(tmp_path: Path, minecraft_container, minecraft_client, minecraft_p
 def test_backup(tmp_path):
     checks = ["ERROR", "WARNING"]
 
-    server_folder = Path.home() / "test-backup-server"
-    server_folder2 = Path.home() / "test-backup-server2"
-    backup_folder = Path.home() / "test-backup-backup"
-    backup_folder_tmp = Path.home() / "test-backup-backup"
+    server_folder = Path(tempfile.gettempdir()) / "test-backup-server"
+    server_folder2 = Path(tempfile.gettempdir()) / "test-backup-server2"
+    backup_folder = Path(tempfile.gettempdir()) / "test-backup-backup"
+    backup_folder_tmp = Path(tempfile.gettempdir()) / "test-backup-backup"
 
     result = run_cli(
         "start",

--- a/tests/test_system/test_cli.py
+++ b/tests/test_system/test_cli.py
@@ -43,7 +43,10 @@ def test_repr(tmp_path: Path, minecraft_container, minecraft_client, minecraft_p
 
     assert "player: georgeTest" in result.stdout
 
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="Permissions error in GH Actions")
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true", reason="Permissions error in GH Actions"
+)
 def test_backup(tmp_path):
     checks = ["ERROR", "WARNING"]
 

--- a/tests/test_system/test_cli.py
+++ b/tests/test_system/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 from shutil import copytree
@@ -41,7 +42,7 @@ def test_repr(tmp_path: Path, minecraft_container, minecraft_client, minecraft_p
 
     assert "player: georgeTest" in result.stdout
 
-
+@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="Permissions error in GH Actions")
 def test_backup(tmp_path):
     checks = ["ERROR", "WARNING"]
 

--- a/tests/test_system/test_world.py
+++ b/tests/test_system/test_world.py
@@ -2,7 +2,6 @@
 System tests for the Copy class
 """
 
-
 from time import sleep
 
 from mciwb.imports import Direction, Item, Iwb, Player, get_client
@@ -28,7 +27,11 @@ def test_world_player_signs(mciwb_world: Iwb, minecraft_player: Player):
     """
     verify printing of the world object
     """
-    sp = 'minecraft:oak_sign{{Text1:\'{{"text":"' "{0}" """"}}'}}"""
+
+    sp = (
+        'minecraft:oak_sign{{front_text:{{messages:[\'{{"text":"{0}"}}\','
+        '\'{{"text":""}}\',\'{{"text":""}}\',\'{{"text":""}}\']}}}}'
+    )
 
     client = get_client()
     # place some action signs in the world and verify they are actioned


### PR DESCRIPTION
* Fixes handling of signs in Minecraft 1.20+ (they changed the NBT for them fairly significantly)
  * This does break previous version of MC but the docker container is on 1.20.4 today
* Updates ipython to 8.20
  * Adds a venv related hack - I couldn't figure out why tox fails with that venv warning/erro but pytest doesn't - disabling it in the test execution path works but is ugly :/
* setting.json update / other whitespace changes seem to be due to vscode / linting changes/updates