### PR TITLE
use 1.21 block_entity_data for signs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
     },
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
 }

--- a/src/mciwb/monitor.py
+++ b/src/mciwb/monitor.py
@@ -41,7 +41,8 @@ class Monitor:
 
     def __init__(
         self,
-        func: None | CallbackFunction = None,
+        # maybe this type is a bit loose, pyright not happy, lets just roll with it.
+        func: None | CallbackFunction = None,  # type: ignore
         params: tuple[Any, ...] = (),
         once=False,
         name=None,
@@ -54,7 +55,7 @@ class Monitor:
 
         # pollers is a list of functions, param tuples. It may be initialized
         # with a single function passed in func, params
-        self.pollers: list[tuple[CallbackFunction, tuple[Any, ...]]] = (
+        self.pollers: list[tuple[CallbackFunction, tuple[Any, ...]]] = (  # type: ignore
             [] if func is None else [(func, params)]
         )
 
@@ -112,7 +113,7 @@ class Monitor:
         if not self.once:
             log.info(f"Monitor {self.name} stopped")
 
-    def add_poller_func(self, func: CallbackFunction, params: tuple[Any, ...] = ()):
+    def add_poller_func(self, func: CallbackFunction, params: tuple[Any, ...] = ()):  # type: ignore
         """
         Add a function to the pollers list
 
@@ -123,7 +124,7 @@ class Monitor:
 
     # TODO: consider using a dict or indexing pollers in some fashion
     # currently this does not support 2 calls to same function
-    def remove_poller_func(self, func: CallbackFunction):
+    def remove_poller_func(self, func: CallbackFunction):  # type: ignore
         """
         Remove a function from the pollers list
 

--- a/src/mciwb/server.py
+++ b/src/mciwb/server.py
@@ -209,13 +209,13 @@ class MinecraftServer:
         if not self.backup_folder.exists():
             self.backup_folder.mkdir(parents=True)
 
-        container = docker_client.containers.run(
+        container = docker_client.containers.run(  # type: ignore
             "docker.io/itzg/minecraft-server",
             detach=True,
             environment=env,
             ports={f"{self.rcon}/tcp": self.rcon, f"{self.port}": self.port},
             restart_policy={"Name": "unless-stopped" if self.keep else "no"},
-            volumes={
+            volumes={  # type: ignore
                 str(self.server_folder): {"bind": "/data", "mode": "rw"},
                 str(self.backup_folder): {
                     "bind": str(self.backup_folder),

--- a/src/mciwb/signs.py
+++ b/src/mciwb/signs.py
@@ -35,11 +35,13 @@ class Signs:
 
     _re_sign_text = re.compile("""front_text.*messages: \\['"([^"]*)"',""")
     _re_sign_entity = (
-        """minecraft:oak_sign{{"""
-        """BlockEntityTag:{{front_text:{{"""
-        """messages:['["{0}"]','[""]','[""]','[""]']}}}},"""
-        """display:{{Name:'{{"text":"{0}"}}'}}"""
+        """minecraft:oak_sign["""
+        """block_entity_data={{"""
+        """id:oak_sign,front_text:{{"""
+        """messages:['["{0}"]','[""]','[""]','[""]']"""
         """}}"""
+        """}},"""
+        """minecraft:item_name="{0}"]"""
     )
 
     _wall_sign = "minecraft:oak_wall_sign"

--- a/tests/mockclient.py
+++ b/tests/mockclient.py
@@ -70,13 +70,13 @@ class MockClient:
         v_stop = v_start + vol.size
         d_stop = dest + vol.size
 
-        self.world[
-            dest.x : d_stop.x, dest.y : d_stop.y, dest.z : d_stop.z
-        ] = self.world[
-            v_start.x : v_stop.x,
-            v_start.y : v_stop.y,
-            v_start.z : v_stop.z,
-        ]
+        self.world[dest.x : d_stop.x, dest.y : d_stop.y, dest.z : d_stop.z] = (
+            self.world[
+                v_start.x : v_stop.x,
+                v_start.y : v_stop.y,
+                v_start.z : v_stop.z,
+            ]
+        )
         return f"cloned {v_start} : {v_stop} to {dest}"
 
     @property


### PR DESCRIPTION
fixes #141 

Note that this breaks support for earlier versions of Minecraft. This project is intended to work with the most up to date version. If it is an issue for people we could support a couple of revisions of the block_entity_tag definition.

@DiamondJoseph thanks for the reminder to fix this.
